### PR TITLE
Add Eurocom Sky MX5 support.

### DIFF
--- a/init-headphone
+++ b/init-headphone
@@ -4,8 +4,9 @@ from __future__ import print_function
 import subprocess
 import os
 import sys
+import re
 
-SUPPORTED_SYSTEM_PRODUCT_NAMES = ["W230SS"]
+SUPPORTED_SYSTEM_PRODUCT_NAMES = ["W230SS", "SKY MX5"]
 SUPPORTED_I2C_BUS_NAMES = ["SMBus I801 adapter at f040"]
 I2C_CLASS_PATH = "/sys/class/i2c-dev"
 CMDLINE_PATH = "/proc/cmdline"
@@ -28,8 +29,7 @@ DATA = [
 
 def get_system_product_name():
     try:
-        return subprocess.check_output(["dmidecode", "-s", "system-product-name"]
-                                       ).strip()
+        return "\n".join([line for line in subprocess.check_output(["dmidecode", "-s", "system-product-name"]).splitlines() if not line.startswith('#')]).strip()
     except OSError:
         print("Error: dmidecode is not installed", file=sys.stderr)
         return False
@@ -141,7 +141,6 @@ def init_headphone():
         return False
     for device_cmd, device_data in DATA:
         i2c_bus.write_byte_data(DEVICE_ADDRESS, device_cmd, device_data)
-    i2c_bus.close()
     return True
 
 if __name__ == "__main__":


### PR DESCRIPTION
Improve dmidecode parsing, as dmidecode prints warning for me and
system-product-name validation fails.

```
% sudo dmidecode -q -s system-product-name            
# SMBIOS implementations newer than version 2.8 are not
# fully supported by this version of dmidecode.
SKY MX5
```

Delete SMBus.close as I don't see this method in SMBus class.

```
Traceback (most recent call last):
  File "./init-headphone", line 148, in <module>
    success = init_headphone()
  File "./init-headphone", line 144, in init_headphone
    i2c_bus.close()
```
